### PR TITLE
fix: 解决主动加载注册模块的问题

### DIFF
--- a/src/login/views/loginContainer.js
+++ b/src/login/views/loginContainer.js
@@ -2,6 +2,7 @@ import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import Login from './login';
 import {login} from '../actions';
+import {actions} from '../../register/';
 
 import './style.css';
 
@@ -119,6 +120,7 @@ class LoginContainer extends Component {
   }
 
   componentDidMount() {
+    this.context.store.dispatch(actions.clearStore());
     this.setState({
       unsubscribe: this.context.store.subscribe(this.onChange)
     });

--- a/src/register/actions.js
+++ b/src/register/actions.js
@@ -37,3 +37,11 @@ export const regist = (username, email, password) => {
     });
   };
 };
+
+// 用户从注册模块注册成功加载登录模块时，调用该方法可清除注册时的 Store 状态，
+// 解决再返回注册模块输入用户名时主动跳转到登录模块的问题
+export const clearStore = () => {
+  return (dispatch) => {
+    dispatch(registStarted());
+  };
+};

--- a/src/register/views/registerContainer.js
+++ b/src/register/views/registerContainer.js
@@ -157,7 +157,6 @@ class RegisterContainer extends Component {
 	this.state.emailInputValue,
 	this.state.passwordInputValue
       ));
-      return;
     } else {
       alert('请检查注册信息');
     }


### PR DESCRIPTION
当用户注册成后加载登录模块后，再返回注册模块输入用户名时，会在不点击注册按钮的情况下，主动加载到登录模块。问题原因在用户注册成功加载到登录模块后，注册时的状态信息保存下来未初始化。